### PR TITLE
[FEAT/#11] like / 저장 탭 구현

### DIFF
--- a/app/src/main/java/com/lab/keyneez/data/entity/LikeData.kt
+++ b/app/src/main/java/com/lab/keyneez/data/entity/LikeData.kt
@@ -2,6 +2,6 @@ package com.lab.keyneez.data.entity
 
 data class LikeData(
     val background: Int,
-    val date: Int,
+    val date: String,
     val title: String
 )

--- a/app/src/main/java/com/lab/keyneez/presentation/main/like/LikeAdapter.kt
+++ b/app/src/main/java/com/lab/keyneez/presentation/main/like/LikeAdapter.kt
@@ -1,6 +1,5 @@
 package com.lab.keyneez.presentation.main.like
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -11,12 +10,13 @@ import com.bumptech.glide.Glide
 import com.lab.keyneez.R
 import com.lab.keyneez.data.entity.LikeData
 
-class LikeAdapter(private val context: Context) :
+class LikeAdapter :
     RecyclerView.Adapter<LikeAdapter.ViewHolder>() {
     var data = mutableListOf<LikeData>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view = LayoutInflater.from(context).inflate(R.layout.item_like_content, parent, false)
+        val view =
+            LayoutInflater.from(parent.context).inflate(R.layout.item_like_content, parent, false)
         return ViewHolder(view)
     }
 
@@ -26,7 +26,7 @@ class LikeAdapter(private val context: Context) :
         holder.bind(data[position])
     }
 
-    inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
         private val imgBackground: ImageView = itemView.findViewById(R.id.iv_like_background)
         private val tvDate: TextView = itemView.findViewById(R.id.tv_like_date)
@@ -34,7 +34,7 @@ class LikeAdapter(private val context: Context) :
 
         fun bind(item: LikeData) {
             Glide.with(itemView).load(item.background).into(imgBackground)
-            tvDate.text = item.date.toString()
+            tvDate.text = item.date
             tvTitle.text = item.title
         }
     }

--- a/app/src/main/java/com/lab/keyneez/presentation/main/like/LikeAdapter.kt
+++ b/app/src/main/java/com/lab/keyneez/presentation/main/like/LikeAdapter.kt
@@ -1,41 +1,34 @@
 package com.lab.keyneez.presentation.main.like
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import com.lab.keyneez.R
 import com.lab.keyneez.data.entity.LikeData
+import com.lab.keyneez.databinding.ItemLikeContentBinding
 
 class LikeAdapter :
-    RecyclerView.Adapter<LikeAdapter.ViewHolder>() {
+    RecyclerView.Adapter<LikeAdapter.getViewHolder>() {
     var data = mutableListOf<LikeData>()
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view =
-            LayoutInflater.from(parent.context).inflate(R.layout.item_like_content, parent, false)
-        return ViewHolder(view)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): getViewHolder {
+        val binding =
+            ItemLikeContentBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return getViewHolder(binding)
     }
 
     override fun getItemCount(): Int = data.size
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: getViewHolder, position: Int) {
         holder.bind(data[position])
     }
 
-    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-
-        private val imgBackground: ImageView = itemView.findViewById(R.id.iv_like_background)
-        private val tvDate: TextView = itemView.findViewById(R.id.tv_like_date)
-        private val tvTitle: TextView = itemView.findViewById(R.id.tv_like_title)
-
+    class getViewHolder(private val binding: ItemLikeContentBinding) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(item: LikeData) {
-            Glide.with(itemView).load(item.background).into(imgBackground)
-            tvDate.text = item.date
-            tvTitle.text = item.title
+            Glide.with(itemView).load(item.background).into(binding.ivLikeBackground)
+            binding.tvLikeDate.text = item.date
+            binding.tvLikeTitle.text = item.title
         }
     }
 }

--- a/app/src/main/java/com/lab/keyneez/presentation/main/like/LikeFragment.kt
+++ b/app/src/main/java/com/lab/keyneez/presentation/main/like/LikeFragment.kt
@@ -2,22 +2,84 @@ package com.lab.keyneez.presentation.main.like
 
 import android.os.Bundle
 import android.view.View
-import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.GridLayoutManager
 import com.lab.keyneez.R
+import com.lab.keyneez.data.entity.LikeData
 import com.lab.keyneez.databinding.FragmentLikeBinding
 import com.lab.keyneez.util.binding.BindingFragment
 
 class LikeFragment : BindingFragment<FragmentLikeBinding>(R.layout.fragment_like) {
     // newinstance() 사용하기
-    private val likeViewModel by viewModels<LikeViewModel>()
+    // private val likeViewModel by viewModels<LikeViewModel>()
+    lateinit var likeAdapter: LikeAdapter
+    val data = mutableListOf<LikeData>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initAdapter()
-        // 여기서 코드 작성
+        initLikeAdapter()
+        initLikeClickListener()
+        binding.btnLikeSearch.setOnClickListener {
+            // 검색화면으로 이동
+        }
     }
 
-    private fun initAdapter() {
+    private fun initLikeClickListener() {
+        binding.btnLikeSave.setOnClickListener {
+            binding.rvLikeContent.smoothScrollToPosition(0)
+        }
+    }
+
+    private fun initLikeAdapter() {
+        likeAdapter = LikeAdapter()
+        binding.rvLikeContent.adapter = likeAdapter
+        binding.rvLikeContent.layoutManager = GridLayoutManager(activity, 2)
+        data.apply {
+            add(
+                LikeData(
+                    background = R.drawable.img_like_background,
+                    date = "12.4.12-10",
+                    title = "청소년 영화관 할인"
+                )
+            )
+            add(
+                LikeData(
+                    background = R.drawable.img_like_background,
+                    date = "12.11-12.17",
+                    title = "청소년 미술관 할인"
+                )
+            )
+            add(
+                LikeData(
+                    background = R.drawable.img_like_background,
+                    date = "12.18-12.24",
+                    title = "청소년 공연장 할인"
+                )
+            )
+            add(
+                LikeData(
+                    background = R.drawable.img_like_background,
+                    date = "12.25-12.31",
+                    title = "청소년 박물관 할인"
+                )
+            )
+            add(
+                LikeData(
+                    background = R.drawable.img_like_background,
+                    date = "1.1-1.7",
+                    title = "청소년 서점 할인"
+                )
+            )
+            add(
+                LikeData(
+                    background = R.drawable.img_like_background,
+                    date = "1.8-1.14",
+                    title = "청소년 강의 할인"
+                )
+            )
+
+            likeAdapter.data = data
+            likeAdapter.notifyDataSetChanged()
+        }
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_like.xml
+++ b/app/src/main/res/layout/fragment_like.xml
@@ -2,7 +2,7 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context=".presentation.main.home.HomeFragment">
+    tools:context=".presentation.main.like.LikeFragment">
 
     <data></data>
 
@@ -12,7 +12,7 @@
         android:layout_height="match_parent">
         <!--폰트의 경우 textappearance로-->
         <TextView
-            android:id="@+id/tv_like_save"
+            android:id="@+id/btn_like_save"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
@@ -46,7 +46,7 @@
             android:paddingHorizontal="12dp"
             android:src="@drawable/ic_like_baseline"
             app:layout_constraintStart_toStartOf="@id/layout_like"
-            app:layout_constraintTop_toBottomOf="@id/tv_like_save" />
+            app:layout_constraintTop_toBottomOf="@id/btn_like_save" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_like_content"
@@ -54,7 +54,6 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="20dp"
             android:layout_marginTop="9dp"
-            android:overScrollMode="never"
             android:paddingTop="26dp"
             app:layout_constraintTop_toBottomOf="@id/iv_like_baseline"
             tools:layoutManager="androidx.recyclerview.widget.GridLayoutManager"

--- a/app/src/main/res/layout/fragment_like.xml
+++ b/app/src/main/res/layout/fragment_like.xml
@@ -51,10 +51,11 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_like_content"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="20dp"
+            android:layout_height="0dp"
             android:layout_marginTop="9dp"
+            android:paddingHorizontal="20dp"
             android:paddingTop="26dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/iv_like_baseline"
             tools:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             tools:listitem="@layout/item_like_content"

--- a/app/src/main/res/layout/fragment_like.xml
+++ b/app/src/main/res/layout/fragment_like.xml
@@ -53,6 +53,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="9dp"
+            android:clipToPadding="false"
             android:paddingHorizontal="20dp"
             android:paddingTop="26dp"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## 관련 이슈
- closed #11 

## 작업 내역
- 저장 뷰 기능 구현

## PR 포인트
- 스크롤이 되긴 되는데 끝까지 안되는 거 같습니다. 이 부분을 확인 해주시면 감사하겠습니다.
- 저장버튼 누르면 리사이클러뷰의 상단으로 올라가는 것을 구현하였습니다.
- 검색버튼 누르면 검색 화면으로 가는 것은 추후에 구현하도록 하겠습니다.

## 실행화면

<!--
![ezgif com-gif-maker](https://user-images.githubusercontent.com/99941493/210164136-396b54e7-8337-4e70-8fc8-4226ff965e6a.gif)

-->

